### PR TITLE
Support Open Ephys fallback binaries

### DIFF
--- a/NeuroScope2.m
+++ b/NeuroScope2.m
@@ -7740,10 +7740,15 @@ end
         startTimes = zeros(1, nEpochs);
         stopTimes = zeros(1, nEpochs);
         fids = zeros(1, nEpochs);
+        fileNChannels = zeros(1, nEpochs);
+        dataChannels = cell(1, nEpochs);
+        excludedChannels = cell(1, nEpochs);
 
         parent_dir = fileparts(basepath);
         sr = session.extracellular.sr;
         nChannels = session.extracellular.nChannels;
+        sampleBytes = getPrecisionBytes(UI.settings.precision);
+        mergePointSamples = loadMergePointSamples(basepath, session);
 
         found_any = false;
         lastStopTime = 0; % Tracks the end of the last successfully processed epoch (for fallback timing)
@@ -7802,11 +7807,24 @@ end
                 lastStopTime = epoch.stopTime;
             else
                 s = dir(foundFile);
-                duration = s.bytes / (nChannels * sr * 2);
+                duration = s.bytes / (nChannels * sr * sampleBytes);
                 startTimes(i) = lastStopTime;
                 stopTimes(i) = lastStopTime + duration;
                 lastStopTime = stopTimes(i);
             end
+            expectedSamples = [];
+            epochFieldName = matlab.lang.makeValidName(epochName);
+            if isfield(mergePointSamples, epochFieldName)
+                sampleRange = mergePointSamples.(epochFieldName);
+                expectedSamples = sampleRange(2) - sampleRange(1);
+                startTimes(i) = sampleRange(1) / sr;
+                stopTimes(i) = sampleRange(2) / sr;
+                lastStopTime = stopTimes(i);
+            elseif isfield(epoch,'startTime') && isfield(epoch,'stopTime') && ~isempty(epoch.startTime) && ~isempty(epoch.stopTime)
+                expectedSamples = round((epoch.stopTime - epoch.startTime) * sr);
+            end
+
+            [fileNChannels(i), dataChannels{i}, excludedChannels{i}] = inferSubEpochChannels(foundFile, expectedSamples, nChannels, sampleBytes);
             found_any = true;
         end
 
@@ -7831,6 +7849,9 @@ end
         epochFileInfo.stopTimes  = stopTimes(sortedIdx);
         epochFileInfo.fileNames  = fileNames(sortedIdx);
         epochFileInfo.fids       = fids(sortedIdx);
+        epochFileInfo.fileNChannels = fileNChannels(sortedIdx);
+        epochFileInfo.dataChannels = dataChannels(sortedIdx);
+        epochFileInfo.excludedChannels = excludedChannels(sortedIdx);
     end
 
     function foundFile = findOpenEphysContinuousDat(epochDir)
@@ -7863,14 +7884,18 @@ end
         streamFolders = cellfun(@fileparts, fullPaths, 'UniformOutput', false);
         streamNames = regexp(streamFolders, '[^\\/]+$', 'match', 'once');
         isLFP = contains(streamNames, 'LFP', 'IgnoreCase', true) | ...
-            ~cellfun(@isempty, regexp(streamNames, '\\.1$', 'once'));
-        fullPaths = fullPaths(~isLFP);
+            ~cellfun(@isempty, regexp(streamNames, '\.1$', 'once'));
+        isMemory = contains(streamNames, 'memory_usage', 'IgnoreCase', true);
+        fullPaths = fullPaths(~isLFP & ~isMemory);
         if isempty(fullPaths)
             return
         end
 
-        % Priority 1: Intan Rhythm Data board (Acquisition_Board-*)
-        idx = find(~cellfun(@isempty, regexpi(fullPaths, 'Acquisition_Board.*Rhythm')), 1, 'first');
+        % Priority 1: Open Ephys acquisition board stream
+        idx = find(contains(fullPaths, 'acquisition_board', 'IgnoreCase', true), 1, 'first');
+        if isempty(idx)
+            idx = find(~cellfun(@isempty, regexpi(fullPaths, 'Acquisition_Board.*Rhythm')), 1, 'first');
+        end
         if ~isempty(idx)
             foundFile = fullPaths{idx};
             return
@@ -7907,6 +7932,7 @@ end
 
         nChannels = data.session.extracellular.nChannels;
         precision = UI.settings.precision;
+        sampleBytes = getPrecisionBytes(precision);
         lsb = UI.settings.leastSignificantBit;
         efi = UI.data.epochFileInfo;
 
@@ -7947,10 +7973,12 @@ end
             fid = efi.fids(epochIdx);
             epochStart = efi.startTimes(epochIdx);
             epochStop = efi.stopTimes(epochIdx);
+            fileNChannels = efi.fileNChannels(epochIdx);
+            dataChannels = efi.dataChannels{epochIdx};
 
             % Byte offset from the beginning of this epoch file
             tOffset = tCurrent - epochStart;
-            byteOffset = round(tOffset * sr) * nChannels * 2;
+            byteOffset = round(tOffset * sr) * fileNChannels * sampleBytes;
             fseek(fid, byteOffset, 'bof');
 
             % How many samples remain in this epoch from the current position?
@@ -7965,7 +7993,8 @@ end
                 continue
             end
 
-            chunk = double(fread(fid, [nChannels, samplesToRead], precision))' * lsb;
+            chunk = double(fread(fid, [fileNChannels, samplesToRead], precision))';
+            chunk = chunk(:, dataChannels) * lsb;
             actualRead = size(chunk, 1);
 
             if actualRead > 0
@@ -7976,6 +8005,69 @@ end
             else
                 break
             end
+        end
+    end
+
+    function mergePointSamples = loadMergePointSamples(basepath, session)
+        mergePointSamples = struct();
+        if ~isfield(session,'general') || ~isfield(session.general,'name') || isempty(session.general.name)
+            return
+        end
+        mergePointsFile = fullfile(basepath, [session.general.name, '.MergePoints.events.mat']);
+        if ~exist(mergePointsFile,'file')
+            return
+        end
+        mergeData = load(mergePointsFile, 'MergePoints');
+        if ~isfield(mergeData,'MergePoints')
+            return
+        end
+        MergePoints = mergeData.MergePoints;
+        if ~isfield(MergePoints,'timestamps_samples') || ~isfield(MergePoints,'foldernames')
+            return
+        end
+        foldernames = MergePoints.foldernames;
+        if isstring(foldernames)
+            foldernames = cellstr(foldernames);
+        end
+        if numel(foldernames) ~= size(MergePoints.timestamps_samples,1)
+            return
+        end
+        for ii = 1:numel(foldernames)
+            fieldName = matlab.lang.makeValidName(foldernames{ii});
+            mergePointSamples.(fieldName) = double(MergePoints.timestamps_samples(ii,:));
+        end
+    end
+
+    function [fileNChannels, dataChannels, excludedChannels] = inferSubEpochChannels(filename, expectedSamples, nChannels, sampleBytes)
+        if isempty(expectedSamples)
+            fileNChannels = nChannels;
+        else
+            fileInfo = dir(filename);
+            fileNChannels = fileInfo.bytes / (expectedSamples * sampleBytes);
+            if abs(fileNChannels - round(fileNChannels)) > 1e-9
+                error('NeuroScope2: Could not infer integer channel count for %s from %d samples and %d bytes.', filename, expectedSamples, fileInfo.bytes)
+            end
+            fileNChannels = round(fileNChannels);
+            if fileNChannels < nChannels
+                error('NeuroScope2: File %s has %d channels but session expects %d.', filename, fileNChannels, nChannels)
+            end
+        end
+        dataChannels = 1:nChannels;
+        excludedChannels = nChannels+1:fileNChannels;
+    end
+
+    function sampleBytes = getPrecisionBytes(precision)
+        switch lower(precision)
+            case {'int16','uint16'}
+                sampleBytes = 2;
+            case {'int32','uint32','single','float32'}
+                sampleBytes = 4;
+            case {'int64','uint64','double','float64'}
+                sampleBytes = 8;
+            case {'int8','uint8','char'}
+                sampleBytes = 1;
+            otherwise
+                error('NeuroScope2: Unsupported precision: %s', precision)
         end
     end
 

--- a/calc_CellMetrics/getWaveformsFromDat.m
+++ b/calc_CellMetrics/getWaveformsFromDat.m
@@ -364,37 +364,61 @@ if numel(foldernames) ~= numel(starts)
     error('Mismatch between MergePoints foldernames and timestamps_samples in %s',mergePointsFile)
 end
 
-segments = repmat(struct('foldername','','datFile','','startSample',0,'endSample',0,'nSamples',0),1,numel(foldernames));
+segments = repmat(struct('foldername','','datFile','','startSample',0,'endSample',0,'nSamples',0,'fileNChannels',0,'dataChannels',[],'excludedChannels',[],'sourceType',''),1,numel(foldernames));
 for i = 1:numel(foldernames)
     foldername = foldernames{i};
     datPath = fullfile(basepath,foldername,'amplifier.dat');
     if ~exist(datPath,'file')
-        error('Expected amplifier.dat for MergePoints segment is missing: %s',datPath)
+        datPath = findOpenEphysContinuousDat(fullfile(basepath,foldername));
+        if isempty(datPath)
+            error('Expected amplifier.dat or Open Ephys continuous.dat for MergePoints segment is missing: %s',fullfile(basepath,foldername))
+        end
+        sourceType = 'Open Ephys continuous.dat';
+    else
+        sourceType = 'amplifier.dat';
     end
     fileInfo = dir(datPath);
-    nSamples = fileInfo.bytes/(sampleBytes*nChannels);
     expectedSamples = stops(i) - starts(i);
-    if nSamples ~= expectedSamples
-        error('Sample count mismatch for %s (MergePoints=%d, amplifier.dat=%d).',datPath,expectedSamples,nSamples)
+    if expectedSamples <= 0
+        error('Invalid MergePoints sample range for %s: start=%d, stop=%d.',foldername,starts(i),stops(i))
+    end
+    fileNChannels = fileInfo.bytes/(sampleBytes*expectedSamples);
+    if abs(fileNChannels - round(fileNChannels)) > 1e-9
+        error('Could not infer an integer channel count for %s from MergePoints samples (%d) and file size (%d bytes).',datPath,expectedSamples,fileInfo.bytes)
+    end
+    fileNChannels = round(fileNChannels);
+    if fileNChannels < nChannels
+        error('Channel count mismatch for %s: file has %d channels but session expects %d.',datPath,fileNChannels,nChannels)
     end
     segments(i).foldername = foldername;
     segments(i).datFile = datPath;
     segments(i).startSample = starts(i);
     segments(i).endSample = stops(i);
-    segments(i).nSamples = nSamples;
+    segments(i).nSamples = expectedSamples;
+    segments(i).fileNChannels = fileNChannels;
+    segments(i).dataChannels = 1:nChannels;
+    segments(i).excludedChannels = nChannels+1:fileNChannels;
+    segments(i).sourceType = sourceType;
 end
 
 waveformSource.mode = 'mergepoints';
 waveformSource.segments = segments;
 waveformSource.precision = precision;
 duration = stops(end)/sr;
-waveformSourceLabel = 'MergePoints amplifier.dat files';
+sourceTypes = unique({segments.sourceType});
+if numel(sourceTypes) == 1 && strcmp(sourceTypes{1},'amplifier.dat')
+    waveformSourceLabel = 'MergePoints amplifier.dat files';
+elseif numel(sourceTypes) == 1 && strcmp(sourceTypes{1},'Open Ephys continuous.dat')
+    waveformSourceLabel = 'MergePoints Open Ephys continuous.dat files';
+else
+    waveformSourceLabel = 'MergePoints mixed binary files';
+end
 end
 
 function [wf, spkTmp] = extractWaveformsFromSource(spkTmp,wfWin,nChannels,LSB,waveformSource)
 switch waveformSource.mode
     case 'single'
-        wf = readWaveformsFromFile(waveformSource.datFile,spkTmp,wfWin,nChannels,LSB,waveformSource.precision);
+        wf = readWaveformsFromFile(waveformSource.datFile,spkTmp,wfWin,nChannels,1:nChannels,LSB,waveformSource.precision);
     case 'mergepoints'
         [spkTmp,segmentIds] = filterSpikesForSegments(spkTmp,wfWin,waveformSource.segments);
         if isempty(spkTmp)
@@ -406,7 +430,7 @@ switch waveformSource.mode
         for iSegment = uniqueSegments(:)'
             idx = find(segmentIds == iSegment);
             localSpikes = spkTmp(idx) - waveformSource.segments(iSegment).startSample;
-            wf(:,idx,:) = readWaveformsFromFile(waveformSource.segments(iSegment).datFile,localSpikes,wfWin,nChannels,LSB,waveformSource.precision);
+            wf(:,idx,:) = readWaveformsFromFile(waveformSource.segments(iSegment).datFile,localSpikes,wfWin,waveformSource.segments(iSegment).fileNChannels,waveformSource.segments(iSegment).dataChannels,LSB,waveformSource.precision);
         end
     otherwise
         error('Unknown waveform source mode: %s',waveformSource.mode)
@@ -427,12 +451,61 @@ end
 segmentIds = segmentIds(order);
 end
 
-function wf = readWaveformsFromFile(datFile,spkTmp,wfWin,nChannels,LSB,precision)
+function wf = readWaveformsFromFile(datFile,spkTmp,wfWin,fileNChannels,dataChannels,LSB,precision)
 rawData = memmapfile(datFile,'Format',precision,'writable',false);
-startIndicies = (spkTmp - wfWin)*nChannels+1;
-stopIndicies = (spkTmp + wfWin)*nChannels;
+startIndicies = (spkTmp - wfWin)*fileNChannels+1;
+stopIndicies = (spkTmp + wfWin)*fileNChannels;
 X = cumsum(accumarray(cumsum([1;stopIndicies(:)-startIndicies(:)+1]),[startIndicies(:);0]-[0;stopIndicies(:)]-1)+1);
-wf = LSB * permute(reshape(double(rawData.Data(X(1:end-1))),nChannels,(wfWin*2),[]),[2,3,1]);
+wf = LSB * permute(reshape(double(rawData.Data(X(1:end-1))),fileNChannels,(wfWin*2),[]),[2,3,1]);
+wf = wf(:,:,dataChannels);
+end
+
+function foundFile = findOpenEphysContinuousDat(epochDir)
+foundFile = '';
+if ~exist(epochDir,'dir')
+    return
+end
+
+hits = dir(fullfile(epochDir,'**','continuous.dat'));
+if isempty(hits)
+    return
+end
+
+fullPaths = fullfile({hits.folder},{hits.name});
+streamFolders = cellfun(@fileparts,fullPaths,'UniformOutput',false);
+streamNames = regexp(streamFolders,'[^\\/]+$','match','once');
+isLFP = contains(streamNames,'LFP','IgnoreCase',true) | ~cellfun(@isempty,regexp(streamNames,'\.1$','once'));
+isMemory = contains(streamNames,'memory_usage','IgnoreCase',true);
+fullPaths = fullPaths(~isLFP & ~isMemory);
+if isempty(fullPaths)
+    return
+end
+
+idx = find(contains(fullPaths,'acquisition_board','IgnoreCase',true),1,'first');
+if ~isempty(idx)
+    foundFile = fullPaths{idx};
+    return
+end
+
+idx = find(~cellfun(@isempty,regexpi(fullPaths,'ProbeA-AP')),1,'first');
+if ~isempty(idx)
+    foundFile = fullPaths{idx};
+    return
+end
+
+idx = find(~cellfun(@isempty,regexpi(fullPaths,'Neuropix.*\.0')),1,'first');
+if ~isempty(idx)
+    foundFile = fullPaths{idx};
+    return
+end
+
+idx = find(~cellfun(@isempty,regexpi(fullPaths,'ProbeA')),1,'first');
+if ~isempty(idx)
+    foundFile = fullPaths{idx};
+    return
+end
+
+foundFile = fullPaths{1};
 end
 
 function sampleBytes = getPrecisionBytes(precision)

--- a/tests/helpers/generate_getWaveformsFromDat_fixture.m
+++ b/tests/helpers/generate_getWaveformsFromDat_fixture.m
@@ -6,6 +6,8 @@ function fixtureData = generate_getWaveformsFromDat_fixture(varargin)
 %   basename.dat
 %   subfolder_01/amplifier.dat
 %   subfolder_02/amplifier.dat
+%   subfolder_01/.../Acquisition_Board-100.acquisition_board/continuous.dat
+%   subfolder_02/.../Acquisition_Board-100.acquisition_board/continuous.dat
 %   basename.MergePoints.events.mat
 %
 % Example:
@@ -59,6 +61,8 @@ segment2 = rawData(segmentSamples + 1:end, :);
 write_binary(fullfile(outputRoot, [basename, '.dat']), rawData);
 write_binary(fullfile(outputRoot, 'subfolder_01', 'amplifier.dat'), segment1);
 write_binary(fullfile(outputRoot, 'subfolder_02', 'amplifier.dat'), segment2);
+write_open_ephys_continuous(outputRoot, 'subfolder_01', segment1);
+write_open_ephys_continuous(outputRoot, 'subfolder_02', segment2);
 
 MergePoints = struct();
 MergePoints.timestamps_samples = [
@@ -119,6 +123,20 @@ spikePlan = struct('timesSec', {});
 spikePlan(1).timesSec = [1.0, 2.0, 3.5, 4.0];
 spikePlan(2).timesSec = [6.0, 7.0, 8.0, 9.0];
 spikePlan(3).timesSec = [2.5, 4.5, 5.5, 7.5, 4.9990, 5.0010];
+end
+
+function write_open_ephys_continuous(outputRoot, foldername, ephysData)
+continuousDir = fullfile(outputRoot, foldername, 'Record Node 101', 'experiment1', 'recording1', ...
+    'continuous', 'Acquisition_Board-100.acquisition_board');
+memoryDir = fullfile(outputRoot, foldername, 'Record Node 101', 'experiment1', 'recording1', ...
+    'continuous', 'Acquisition_Board-100.memory_usage');
+mkdir(continuousDir);
+mkdir(memoryDir);
+
+nSamples = size(ephysData, 1);
+adcData = int16([repmat(101, nSamples, 1), repmat(-101, nSamples, 1)]);
+write_binary(fullfile(continuousDir, 'continuous.dat'), [ephysData, adcData]);
+write_binary(fullfile(memoryDir, 'continuous.dat'), int16(zeros(max(1, round(nSamples / 200)), 1)));
 end
 
 function write_binary(filename, data)

--- a/tests/test_getWaveformsFromDat_mergepoints.m
+++ b/tests/test_getWaveformsFromDat_mergepoints.m
@@ -48,6 +48,46 @@ verifyFalse(testCase, any(abs(fallbackSpikes.waveforms.times{3} - fixtureData.bo
 verifyFalse(testCase, any(abs(fallbackSpikes.waveforms.times{3} - fixtureData.boundarySpikeSec(2)) < 1e-12));
 end
 
+function testOpenEphysFallbackDropsTrailingAdcChannels(testCase)
+repoRoot = fileparts(fileparts(mfilename('fullpath')));
+addpath(genpath(repoRoot));
+
+fixtureData = generate_getWaveformsFromDat_fixture('outputRoot', tempname);
+cleanupObj = onCleanup(@() cleanup_fixture(fixtureData.basepath)); %#ok<NASGU>
+
+directSpikes = run_waveform_extraction(fixtureData.spikes, fixtureData.session);
+
+datFile = fullfile(fixtureData.basepath, [fixtureData.basename, '.dat']);
+backupDatFile = [datFile, '.bak'];
+movefile(datFile, backupDatFile);
+restoreDatObj = onCleanup(@() restore_dat(datFile, backupDatFile)); %#ok<NASGU>
+
+amplifierFiles = {
+    fullfile(fixtureData.basepath, 'subfolder_01', 'amplifier.dat'), ...
+    fullfile(fixtureData.basepath, 'subfolder_02', 'amplifier.dat')};
+backupAmplifierFiles = move_files_to_backup(amplifierFiles);
+restoreAmplifierObj = onCleanup(@() restore_files_from_backup(amplifierFiles, backupAmplifierFiles)); %#ok<NASGU>
+
+fallbackSpikes = run_waveform_extraction(fixtureData.spikes, fixtureData.session);
+
+verifyEqual(testCase, fallbackSpikes.processinginfo.params.WaveformsSource, 'MergePoints Open Ephys continuous.dat files');
+verifyEqual(testCase, directSpikes.cluID, fallbackSpikes.cluID);
+
+for iUnit = 1:numel(fixtureData.spikes.times)
+    verifyEqual(testCase, fallbackSpikes.channels_all{iUnit}, 1:fixtureData.session.extracellular.nChannels);
+    verifyEqual(testCase, fallbackSpikes.maxWaveformCh1(iUnit), fixtureData.expectedPeakChannels(iUnit));
+
+    directSafe = restrict_times_to_intervals(directSpikes.waveforms.times{iUnit}, fixtureData.safeIntervalsSec);
+    fallbackSafe = restrict_times_to_intervals(fallbackSpikes.waveforms.times{iUnit}, fixtureData.safeIntervalsSec);
+    verifyEqual(testCase, directSafe(:), fallbackSafe(:), 'AbsTol', 1e-12);
+
+    if iUnit <= 2
+        verifyEqual(testCase, directSpikes.rawWaveform{iUnit}, fallbackSpikes.rawWaveform{iUnit}, 'AbsTol', 1e-9);
+        verifyEqual(testCase, directSpikes.filtWaveform{iUnit}, fallbackSpikes.filtWaveform{iUnit}, 'AbsTol', 1e-9);
+    end
+end
+end
+
 function spikesOut = run_waveform_extraction(spikesIn, session)
 rng(1);
 spikesOut = getWaveformsFromDat( ...
@@ -69,6 +109,24 @@ end
 function restore_dat(datFile, backupDatFile)
 if exist(backupDatFile, 'file') == 2 && exist(datFile, 'file') ~= 2
     movefile(backupDatFile, datFile);
+end
+end
+
+function backupFiles = move_files_to_backup(files)
+backupFiles = cell(size(files));
+for i = 1:numel(files)
+    backupFiles{i} = [files{i}, '.bak'];
+    if exist(files{i}, 'file') == 2
+        movefile(files{i}, backupFiles{i});
+    end
+end
+end
+
+function restore_files_from_backup(files, backupFiles)
+for i = 1:numel(files)
+    if exist(backupFiles{i}, 'file') == 2 && exist(files{i}, 'file') ~= 2
+        movefile(backupFiles{i}, files{i});
+    end
 end
 end
 


### PR DESCRIPTION
## Summary
- Extend `getWaveformsFromDat` MergePoints fallback to read Open Ephys `continuous.dat` files when merged `basename.dat` and per-epoch `amplifier.dat` are missing.
- Infer per-segment file channel counts from `MergePoints.timestamps_samples` and file size, then drop trailing ADC channels by reading only the first `session.extracellular.nChannels` channels.
- Apply the same channel-count handling to NeuroScope2 sub-epoch raw-data fallback so Open Ephys acquisition-board files with appended ADC channels display correctly.
- Add a synthetic MATLAB regression fixture/test covering Open Ephys-style nested `continuous.dat` files with trailing ADC channels.

## Validation
- `matlab -batch "addpath(genpath(pwd)); results = runtests('tests/test_getWaveformsFromDat_mergepoints.m'); assertSuccess(results);"`
- `matlab -batch "addpath(genpath(pwd)); issues = checkcode('NeuroScope2.m'); fprintf('checkcode issues: %d\n', numel(issues));"` succeeded; it reports 192 existing lint issues in `NeuroScope2.m`.
- Manual NeuroScope2 check on real Open Ephys data confirmed raw traces display correctly without `basename.dat`.

## Notes
- The PR targets `ayalab1/CellExplorer`, not the upstream original repository.
- Existing local unstaged changes in `calc_CellMetrics/loadSpikes.m` and `manual_tests/` were intentionally left out of this commit.