### PR TITLE
Fix subepoch fallback channel inference for Intan and Open Ephys

### DIFF
--- a/NeuroScope2.m
+++ b/NeuroScope2.m
@@ -7824,7 +7824,11 @@ end
                 expectedSamples = round((epoch.stopTime - epoch.startTime) * sr);
             end
 
-            [fileNChannels(i), dataChannels{i}, excludedChannels{i}] = inferSubEpochChannels(foundFile, expectedSamples, nChannels, sampleBytes);
+            [fileNChannels(i), dataChannels{i}, excludedChannels{i}, fileNSamples] = inferSubEpochChannels(foundFile, expectedSamples, nChannels, sampleBytes);
+            if ~isempty(fileNSamples) && ~isempty(expectedSamples)
+                stopTimes(i) = startTimes(i) + fileNSamples / sr;
+                lastStopTime = stopTimes(i);
+            end
             found_any = true;
         end
 
@@ -8035,22 +8039,38 @@ end
         for ii = 1:numel(foldernames)
             fieldName = matlab.lang.makeValidName(foldernames{ii});
             mergePointSamples.(fieldName) = double(MergePoints.timestamps_samples(ii,:));
+            localFieldName = matlab.lang.makeValidName(localEpochNameFromPath(foldernames{ii}));
+            mergePointSamples.(localFieldName) = double(MergePoints.timestamps_samples(ii,:));
         end
     end
 
-    function [fileNChannels, dataChannels, excludedChannels] = inferSubEpochChannels(filename, expectedSamples, nChannels, sampleBytes)
+    function epochName = localEpochNameFromPath(foldername)
+        foldername = char(foldername);
+        parts = regexp(strrep(foldername, '\', '/'), '[^/]+', 'match');
+        if isempty(parts)
+            epochName = foldername;
+        else
+            epochName = parts{end};
+        end
+    end
+
+    function [fileNChannels, dataChannels, excludedChannels, fileNSamples] = inferSubEpochChannels(filename, expectedSamples, nChannels, sampleBytes)
+        fileInfo = dir(filename);
         if isempty(expectedSamples)
             fileNChannels = nChannels;
+            fileNSamples = fileInfo.bytes / (fileNChannels * sampleBytes);
         else
-            fileInfo = dir(filename);
-            fileNChannels = fileInfo.bytes / (expectedSamples * sampleBytes);
-            if abs(fileNChannels - round(fileNChannels)) > 1e-9
+            candidateSamples = unique([expectedSamples, expectedSamples + 1, expectedSamples - 1], 'stable');
+            candidateSamples = candidateSamples(candidateSamples > 0);
+            candidateNChannels = fileInfo.bytes ./ (candidateSamples * sampleBytes);
+            isIntegerChannelCount = abs(candidateNChannels - round(candidateNChannels)) <= 1e-9;
+            isUsableChannelCount = isIntegerChannelCount & round(candidateNChannels) >= nChannels;
+            if ~any(isUsableChannelCount)
                 error('NeuroScope2: Could not infer integer channel count for %s from %d samples and %d bytes.', filename, expectedSamples, fileInfo.bytes)
             end
-            fileNChannels = round(fileNChannels);
-            if fileNChannels < nChannels
-                error('NeuroScope2: File %s has %d channels but session expects %d.', filename, fileNChannels, nChannels)
-            end
+            bestIdx = find(isUsableChannelCount, 1, 'first');
+            fileNSamples = candidateSamples(bestIdx);
+            fileNChannels = round(candidateNChannels(bestIdx));
         end
         dataChannels = 1:nChannels;
         excludedChannels = nChannels+1:fileNChannels;

--- a/calc_CellMetrics/getWaveformsFromDat.m
+++ b/calc_CellMetrics/getWaveformsFromDat.m
@@ -366,12 +366,13 @@ end
 
 segments = repmat(struct('foldername','','datFile','','startSample',0,'endSample',0,'nSamples',0,'fileNChannels',0,'dataChannels',[],'excludedChannels',[],'sourceType',''),1,numel(foldernames));
 for i = 1:numel(foldernames)
-    foldername = foldernames{i};
-    datPath = fullfile(basepath,foldername,'amplifier.dat');
+    foldername = localEpochNameFromPath(foldernames{i});
+    epochDir = resolveMergePointEpochDir(basepath,foldernames{i});
+    datPath = fullfile(epochDir,'amplifier.dat');
     if ~exist(datPath,'file')
-        datPath = findOpenEphysContinuousDat(fullfile(basepath,foldername));
+        datPath = findOpenEphysContinuousDat(epochDir);
         if isempty(datPath)
-            error('Expected amplifier.dat or Open Ephys continuous.dat for MergePoints segment is missing: %s',fullfile(basepath,foldername))
+            error('Expected amplifier.dat or Open Ephys continuous.dat for MergePoints segment is missing: %s',epochDir)
         end
         sourceType = 'Open Ephys continuous.dat';
     else
@@ -382,18 +383,21 @@ for i = 1:numel(foldernames)
     if expectedSamples <= 0
         error('Invalid MergePoints sample range for %s: start=%d, stop=%d.',foldername,starts(i),stops(i))
     end
-    fileNChannels = fileInfo.bytes/(sampleBytes*expectedSamples);
-    if abs(fileNChannels - round(fileNChannels)) > 1e-9
+    candidateSamples = unique([expectedSamples, expectedSamples + 1, expectedSamples - 1],'stable');
+    candidateSamples = candidateSamples(candidateSamples > 0);
+    candidateNChannels = fileInfo.bytes ./ (sampleBytes * candidateSamples);
+    isIntegerChannelCount = abs(candidateNChannels - round(candidateNChannels)) <= 1e-9;
+    isUsableChannelCount = isIntegerChannelCount & round(candidateNChannels) >= nChannels;
+    if ~any(isUsableChannelCount)
         error('Could not infer an integer channel count for %s from MergePoints samples (%d) and file size (%d bytes).',datPath,expectedSamples,fileInfo.bytes)
     end
-    fileNChannels = round(fileNChannels);
-    if fileNChannels < nChannels
-        error('Channel count mismatch for %s: file has %d channels but session expects %d.',datPath,fileNChannels,nChannels)
-    end
+    bestIdx = find(isUsableChannelCount,1,'first');
+    expectedSamples = candidateSamples(bestIdx);
+    fileNChannels = round(candidateNChannels(bestIdx));
     segments(i).foldername = foldername;
     segments(i).datFile = datPath;
     segments(i).startSample = starts(i);
-    segments(i).endSample = stops(i);
+    segments(i).endSample = starts(i) + expectedSamples;
     segments(i).nSamples = expectedSamples;
     segments(i).fileNChannels = fileNChannels;
     segments(i).dataChannels = 1:nChannels;
@@ -404,7 +408,7 @@ end
 waveformSource.mode = 'mergepoints';
 waveformSource.segments = segments;
 waveformSource.precision = precision;
-duration = stops(end)/sr;
+duration = max([segments.endSample])/sr;
 sourceTypes = unique({segments.sourceType});
 if numel(sourceTypes) == 1 && strcmp(sourceTypes{1},'amplifier.dat')
     waveformSourceLabel = 'MergePoints amplifier.dat files';
@@ -506,6 +510,31 @@ if ~isempty(idx)
 end
 
 foundFile = fullPaths{1};
+end
+
+function epochDir = resolveMergePointEpochDir(basepath,foldername)
+localFolderName = localEpochNameFromPath(foldername);
+candidates = {
+    fullfile(basepath,localFolderName), ...
+    fullfile(basepath,char(foldername)), ...
+    char(foldername)};
+for i = 1:numel(candidates)
+    if exist(candidates{i},'dir')
+        epochDir = candidates{i};
+        return
+    end
+end
+epochDir = fullfile(basepath,localFolderName);
+end
+
+function epochName = localEpochNameFromPath(foldername)
+foldername = char(foldername);
+parts = regexp(strrep(foldername,'\','/'),'[^/]+','match');
+if isempty(parts)
+    epochName = foldername;
+else
+    epochName = parts{end};
+end
 end
 
 function sampleBytes = getPrecisionBytes(precision)


### PR DESCRIPTION
This fixes subepoch binary fallback loading when no concatenated `.dat` file is present.

Root cause:
- Open Ephys `continuous.dat` files can include extra trailing channels beyond `session.extracellular.nChannels`.
- The fallback channel inference relied on `MergePoints.timestamps_samples` sample counts.
- MergePoints sample ranges behave like inclusive ranges, causing an off-by-one sample mismatch and non-integer inferred channel counts.

Changes:
- Infer file channel count using `expectedSamples`, `expectedSamples + 1`, and `expectedSamples - 1`, choosing the one consistent with file size.
- Preserve reading only `1:session.extracellular.nChannels` when fallback files contain extra channels.
- Resolve `MergePoints.foldernames` that contain full Linux paths by matching the local epoch folder name.

Validated on:
- Open Ephys: `RM018_day39_260620`
  - `continuous.dat`: 200 channels
  - session: 192 channels
  - extra ADC channels excluded
- Intan: `sake_day10`
  - `amplifier.dat`: 128 channels
  - session: 128 channels

Tests:
- `tests/test_getWaveformsFromDat_mergepoints.m`
- Minimal `getWaveformsFromDat` fallback check on both real sessions